### PR TITLE
Fix mobile header overflow with off-canvas drawer

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -25,6 +25,8 @@
     {% include "partials/footer.njk" %}
   </div>
 
+  {% include "partials/mobile-drawer.njk" %}
+
   <script type="module" src="/assets/ts/main.ts"></script>
 </body>
 </html>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -2,29 +2,41 @@
   <div class="container container--wide header__inner">
     <a href="/" class="header__logo">Fabrizio Palladino</a>
 
-    <nav class="header__nav" aria-label="Main navigation">
-      {% for item in navigation %}
-        <a href="{{ item.url }}"{% if page.url == item.url %} aria-current="page"{% endif %}>
-          {{ item.label }}
-        </a>
-      {% endfor %}
+    <div class="header__cluster">
+      <nav class="header__nav" aria-label="Main navigation">
+        {% for item in navigation %}
+          <a href="{{ item.url }}"{% if page.url == item.url %} aria-current="page"{% endif %}>
+            {{ item.label }}
+          </a>
+        {% endfor %}
+      </nav>
 
-      <button class="theme-toggle" type="button" aria-label="Toggle dark mode">
-        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="12" cy="12" r="5"></circle>
-          <line x1="12" y1="1" x2="12" y2="3"></line>
-          <line x1="12" y1="21" x2="12" y2="23"></line>
-          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-          <line x1="1" y1="12" x2="3" y2="12"></line>
-          <line x1="21" y1="12" x2="23" y2="12"></line>
-          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-        </svg>
-        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-        </svg>
-      </button>
-    </nav>
+      <div class="header__actions">
+        <button class="theme-toggle" type="button" aria-label="Toggle dark mode">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+          </svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+        </button>
+
+        <button class="header__menu-toggle" type="button" aria-expanded="false" aria-controls="header-drawer" aria-label="Menu">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6"></line>
+            <line x1="3" y1="12" x2="21" y2="12"></line>
+            <line x1="3" y1="18" x2="21" y2="18"></line>
+          </svg>
+        </button>
+      </div>
+    </div>
   </div>
 </header>

--- a/src/_includes/partials/mobile-drawer.njk
+++ b/src/_includes/partials/mobile-drawer.njk
@@ -1,0 +1,16 @@
+<nav id="header-drawer" class="header__drawer" aria-label="Mobile menu" inert>
+  <button class="header__drawer-close" type="button" aria-label="Close menu">
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <line x1="18" y1="6" x2="6" y2="18"></line>
+      <line x1="6" y1="6" x2="18" y2="18"></line>
+    </svg>
+  </button>
+
+  {% for item in navigation %}
+    <a href="{{ item.url }}"{% if page.url == item.url %} aria-current="page"{% endif %}>
+      {{ item.label }}
+    </a>
+  {% endfor %}
+</nav>
+
+<div class="header__backdrop" hidden></div>

--- a/src/assets/css/components.css
+++ b/src/assets/css/components.css
@@ -30,10 +30,22 @@
   color: var(--fp-accent);
 }
 
+.header__cluster {
+  display: flex;
+  align-items: center;
+  gap: var(--fp-space-sm);
+}
+
 .header__nav {
   display: flex;
   align-items: center;
   gap: var(--fp-space-sm);
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--fp-space-xs);
 }
 
 .header__nav a {
@@ -101,6 +113,134 @@
 
 [data-theme="dark"] .theme-toggle .icon-moon {
   display: block;
+}
+
+/* ————————————————————————————————
+   Mobile menu — hamburger, drawer, backdrop
+   ———————————————————————————————— */
+.header__menu-toggle {
+  background: none;
+  border: 1px solid var(--fp-border);
+  border-radius: var(--fp-radius);
+  cursor: pointer;
+  padding: var(--fp-space-xs);
+  color: var(--fp-text);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  transition: border-color var(--fp-transition), color var(--fp-transition);
+}
+
+.header__menu-toggle:hover {
+  border-color: var(--fp-accent);
+  color: var(--fp-accent);
+}
+
+.header__menu-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+@media (max-width: 599px) {
+  .header__nav {
+    display: none;
+  }
+
+  .header__menu-toggle {
+    display: inline-flex;
+  }
+}
+
+.header__drawer {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: min(85vw, 320px);
+  background: var(--fp-bg-surface);
+  border-left: 1px solid var(--fp-border);
+  padding: var(--fp-space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fp-space-sm);
+  transform: translateX(100%);
+  transition: transform 250ms ease;
+  z-index: 100;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+}
+
+.header__drawer[data-open="true"] {
+  transform: translateX(0);
+}
+
+.header__drawer-close {
+  background: none;
+  border: 1px solid var(--fp-border);
+  border-radius: var(--fp-radius);
+  cursor: pointer;
+  padding: var(--fp-space-xs);
+  color: var(--fp-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  align-self: flex-end;
+  margin-bottom: var(--fp-space-sm);
+  transition: border-color var(--fp-transition), color var(--fp-transition);
+}
+
+.header__drawer-close:hover {
+  border-color: var(--fp-accent);
+  color: var(--fp-accent);
+}
+
+.header__drawer-close svg {
+  width: 18px;
+  height: 18px;
+}
+
+.header__drawer a {
+  display: block;
+  font-size: var(--fp-text-base);
+  text-decoration: none;
+  color: var(--fp-text-muted);
+  padding: var(--fp-space-sm) 0;
+  border-bottom: 1px solid var(--fp-border);
+  transition: color var(--fp-transition);
+}
+
+.header__drawer a:hover,
+.header__drawer a[aria-current="page"] {
+  color: var(--fp-text);
+}
+
+.header__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 99;
+  touch-action: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header__drawer {
+    transition: none;
+  }
+}
+
+/* Scroll lock applied to <html> when drawer is open.
+   We deliberately use overflow:hidden rather than the body-fixed pattern
+   because the body-fixed pattern breaks our position:sticky header
+   (sticky degrades to relative when its containing block is taken out
+   of normal flow). Modern iOS Safari (15+) respects overflow:hidden on
+   documentElement, and combined with touch-action:none on the backdrop,
+   touch scrolling is prevented. */
+.scroll-locked {
+  overflow: hidden;
 }
 
 /* ————————————————————————————————

--- a/src/assets/ts/main.ts
+++ b/src/assets/ts/main.ts
@@ -1,10 +1,12 @@
 import { initDarkMode } from "./dark-mode";
 import { initScrollReveal } from "./scroll-reveal";
 import { initFonts } from "./fonts";
+import { initMobileMenu } from "./mobile-menu";
 
 initDarkMode();
 initFonts();
 
 document.addEventListener("DOMContentLoaded", () => {
   initScrollReveal();
+  initMobileMenu();
 });

--- a/src/assets/ts/mobile-menu.ts
+++ b/src/assets/ts/mobile-menu.ts
@@ -1,0 +1,96 @@
+export function initMobileMenu(): void {
+  const toggle = document.querySelector<HTMLButtonElement>(".header__menu-toggle");
+  const drawer = document.querySelector<HTMLElement>("#header-drawer");
+  const closeBtn = drawer?.querySelector<HTMLButtonElement>(".header__drawer-close");
+  const backdrop = document.querySelector<HTMLElement>(".header__backdrop");
+
+  if (!toggle || !drawer || !closeBtn || !backdrop) return;
+
+  // Selectively inert when drawer is open: everything user-interactive
+  // EXCEPT .header__actions (theme toggle + hamburger button) and the
+  // drawer itself. This keeps the visible header controls usable.
+  const inertSelectors = [
+    ".skip-link",
+    ".header__logo",
+    ".header__nav",
+    "#main",
+    ".footer",
+  ];
+  const inertTargets = inertSelectors
+    .map((sel) => document.querySelector<HTMLElement>(sel))
+    .filter((el): el is HTMLElement => el !== null);
+
+  let isOpen = false;
+
+  function preventTouchMove(e: TouchEvent): void {
+    if (!isOpen) return;
+    if (drawer!.contains(e.target as Node)) return;
+    e.preventDefault();
+  }
+
+  function open(): void {
+    if (isOpen) return;
+    isOpen = true;
+    drawer!.removeAttribute("inert");
+    drawer!.dataset.open = "true";
+    backdrop!.removeAttribute("hidden");
+    toggle!.setAttribute("aria-expanded", "true");
+    toggle!.setAttribute("aria-label", "Close menu");
+    inertTargets.forEach((el) => el.setAttribute("inert", ""));
+    document.documentElement.classList.add("scroll-locked");
+    document.addEventListener("touchmove", preventTouchMove, { passive: false });
+    requestAnimationFrame(() => closeBtn!.focus());
+  }
+
+  function close(): void {
+    if (!isOpen) return;
+    isOpen = false;
+    drawer!.setAttribute("inert", "");
+    delete drawer!.dataset.open;
+    backdrop!.setAttribute("hidden", "");
+    toggle!.setAttribute("aria-expanded", "false");
+    toggle!.setAttribute("aria-label", "Menu");
+    inertTargets.forEach((el) => el.removeAttribute("inert"));
+    document.documentElement.classList.remove("scroll-locked");
+    document.removeEventListener("touchmove", preventTouchMove);
+    requestAnimationFrame(() => toggle!.focus());
+  }
+
+  toggle.addEventListener("click", () => {
+    if (isOpen) close();
+    else open();
+  });
+  closeBtn.addEventListener("click", close);
+  backdrop.addEventListener("click", close);
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && isOpen) close();
+  });
+
+  // Focus trap inside drawer
+  drawer.addEventListener("keydown", (e) => {
+    if (e.key !== "Tab" || !isOpen) return;
+
+    const focusable = drawer!.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
+
+  // Close drawer if viewport widens past mobile breakpoint
+  const mq = window.matchMedia("(min-width: 600px)");
+  mq.addEventListener("change", (e) => {
+    if (e.matches && isOpen) close();
+  });
+}


### PR DESCRIPTION
## Summary

Below 600px, the inline header (logo + 4 nav links + theme toggle) overflows and produces a horizontal scrollbar. This PR replaces the inline nav with an off-canvas drawer pattern: a hamburger button replaces the inline nav links at mobile widths, and tapping it slides in a drawer from the right with a backdrop. Theme toggle stays visible and interactive in the header at all widths.

## Architecture choices (deliberate)

- **Drawer + backdrop are siblings of `.page`** in `base.njk`, NOT inside the sticky `<header>`. `position: sticky` creates a stacking context that would otherwise clip drawer z-index.
- **Scroll lock uses `html { overflow: hidden }`** + `touch-action: none` on backdrop + `touchmove` preventDefault outside drawer. The body-fixed pattern would break our sticky header (sticky degrades to relative when its containing block is out of normal flow).
- **Selective inert** on `[skip-link, header__logo, header__nav, main, footer]` rather than `.page` — so theme toggle and hamburger remain interactive while drawer is open.
- **`requestAnimationFrame` around `focus()` calls** to avoid a Safari race where focus on a just-uninerted element drops to `<body>`.

## Accessibility

- `aria-expanded`, `aria-controls`, `aria-label` flips between "Menu" / "Close menu" on toggle.
- Focus trap inside drawer; focus returns to toggle on close.
- ESC closes; backdrop click closes; resize past 600px while open closes cleanly.
- Native `inert` attribute — supported in Chrome 102+, Safari 15.5+, Firefox 112+ (all shipped 2022).
- `prefers-reduced-motion` disables transition.

## How to test

- [ ] Mobile viewport (375px / 414px): hamburger appears, inline nav hidden, no horizontal scroll.
- [ ] Tap hamburger → drawer slides in from right; focus moves to close button.
- [ ] Backdrop click closes drawer; focus returns to hamburger.
- [ ] ESC closes drawer.
- [ ] Tab through drawer cycles only between drawer's focusable elements (close button + 4 nav links).
- [ ] At 600px+: hamburger hidden, inline nav visible, drawer not visible.
- [ ] Theme toggle works on mobile both before opening drawer and while drawer is closed.
- [ ] Resize from 375px (drawer open) to 1200px → drawer closes cleanly.
- [ ] Real iOS Safari device: drawer doesn't allow underlying page to scroll; sticky header stays put.
- [ ] VoiceOver / NVDA: drawer announces correctly; only one nav landmark active at any time.

## Files changed

- `src/_includes/partials/header.njk` — restructured: logo + cluster (nav + actions).
- `src/_includes/partials/mobile-drawer.njk` — NEW.
- `src/_includes/layouts/base.njk` — includes drawer as sibling of `.page`.
- `src/assets/css/components.css` — hamburger, drawer, backdrop, breakpoint, scroll-lock.
- `src/assets/ts/main.ts` — registers new module.
- `src/assets/ts/mobile-menu.ts` — NEW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)